### PR TITLE
Unshadow `socket` module

### DIFF
--- a/openvpn_api/vpn.py
+++ b/openvpn_api/vpn.py
@@ -18,11 +18,11 @@ class VPNType:
 
 
 class VPN:
-    def __init__(self, host: Optional[str] = None, port: Optional[int] = None, socket: Optional[str] = None):
-        if (socket and host) or (socket and port) or (not socket and not host and not port):
+    def __init__(self, host: Optional[str] = None, port: Optional[int] = None, unix_socket: Optional[str] = None):
+        if (unix_socket and host) or (unix_socket and port) or (not unix_socket and not host and not port):
             raise errors.VPNError("Must specify either socket or host and port")
-        if socket:
-            self._mgmt_socket = socket
+        if unix_socket:
+            self._mgmt_socket = unix_socket
             self._type = VPNType.UNIX_SOCKET
         else:
             self._mgmt_host = host

--- a/openvpn_api/vpn.py
+++ b/openvpn_api/vpn.py
@@ -28,7 +28,7 @@ class VPN:
             self._mgmt_host = host
             self._mgmt_port = port
             self._type = VPNType.IP
-        self._socket = None
+        self._socket = None  # type: Optional[socket.socket]
         # Initialise release info and daemon state caches
         self._release = None  # type: Optional[str]
 

--- a/openvpn_api/vpn.py
+++ b/openvpn_api/vpn.py
@@ -105,7 +105,7 @@ class VPN:
         logger.debug("Sending cmd: %r", cmd.strip())
         self._socket_send(cmd + "\n")
         if cmd.startswith("kill") or cmd.startswith("client-kill"):
-            return
+            return None
         resp = self._socket_recv()
         if cmd.strip() not in ("load-stats", "signal SIGTERM"):
             while not resp.strip().endswith("END"):

--- a/tests/test_vpn_model.py
+++ b/tests/test_vpn_model.py
@@ -26,7 +26,7 @@ class TestVPNModel(unittest.TestCase):
 
     def test_host_port_socket(self):
         with self.assertRaises(errors.VPNError) as ctx:
-            VPN(host="localhost", port=1234, socket="file.sock")
+            VPN(host="localhost", port=1234, unix_socket="file.sock")
         self.assertEqual("Must specify either socket or host and port", str(ctx.exception))
 
     def test_host_port(self):
@@ -37,13 +37,13 @@ class TestVPNModel(unittest.TestCase):
         self.assertEqual(vpn.mgmt_address, "localhost:1234")
 
     def test_socket(self):
-        vpn = VPN(socket="file.sock")
+        vpn = VPN(unix_socket="file.sock")
         self.assertEqual(vpn._mgmt_socket, "file.sock")
         self.assertEqual(vpn.type, VPNType.UNIX_SOCKET)
         self.assertEqual(vpn.mgmt_address, "file.sock")
 
     def test_initialisation(self):
-        vpn = VPN(socket="file.sock")
+        vpn = VPN(unix_socket="file.sock")
         self.assertIsNone(vpn._release)
         self.assertIsNone(vpn._socket)
 


### PR DESCRIPTION
Another thing for #11. This renames one of the init parameters, so its not backwards compatible.

Changes in this PR:
- Rename parameter to unshadow `socket` module
- Add type hinting for socket
- Make `return` explicit for mypy happiness